### PR TITLE
Increased annunciator offsets to 0.95 in Zibo 737

### DIFF
--- a/B737-800X/sd15/actions.yaml
+++ b/B737-800X/sd15/actions.yaml
@@ -4,7 +4,7 @@ actions:
     type: single
     icon: firewarn
     dataref: laminar/B738/annunciator/fire_bell_annun
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: FlyWithLua/streamdeck_handler/capt_fire_warn_start
     command-release: FlyWithLua/streamdeck_handler/capt_fire_warn_end
   - index: 1
@@ -12,7 +12,7 @@ actions:
     type: single
     icon: mastercaution
     dataref: laminar/B738/annunciator/master_caution_light
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: FlyWithLua/streamdeck_handler/capt_master_caution_start
     command-release: FlyWithLua/streamdeck_handler/capt_master_caution_end
   - index: 2
@@ -20,7 +20,7 @@ actions:
     type: single
     icon: apprst
     dataref: laminar/B738/annunciator/ap_disconnect1
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: FlyWithLua/streamdeck_handler/ap_prst_start
     command-release: FlyWithLua/streamdeck_handler/ap_prst_end
   - index: 3
@@ -28,7 +28,7 @@ actions:
     type: single
     icon: atprst
     dataref: laminar/B738/annunciator/at_disconnect1
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: FlyWithLua/streamdeck_handler/at_prst_start
     command-release: FlyWithLua/streamdeck_handler/at_prst_end
   - index: 4
@@ -36,7 +36,7 @@ actions:
     type: single
     icon: fmcprst
     dataref: laminar/B738/annunciator/at_fms_disconnect1
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: FlyWithLua/streamdeck_handler/fmc_prst_start
     command-release: FlyWithLua/streamdeck_handler/fmc_prst_end
   - index: 5
@@ -44,19 +44,19 @@ actions:
     type: single
     icon: speedbrakearmed
     dataref: laminar/B738/annunciator/speedbrake_armed
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 6
     name: speedbrake do not arm
     type: single
     icon: speedbrakedonotarm
     dataref: laminar/B738/annunciator/speedbrake_extend
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 7
     name: stab out of trim
     type: single
     icon: staboutoftrim
     dataref: laminar/B738/annunciator/stab_out_of_trim
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 11
     name: flaps
     type: dir
@@ -78,13 +78,13 @@ actions:
     type: single
     icon: leflapstransit
     dataref: laminar/B738/annunciator/slats_transit
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 13
     name: le flaps ext
     type: single
     icon: leflapsext
     dataref: laminar/B738/annunciator/slats_extend
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 10
     name: left
     type: dir

--- a/B737-800X/sd15/aftovhd.yaml
+++ b/B737-800X/sd15/aftovhd.yaml
@@ -10,49 +10,49 @@ actions:
     type: none
     icon: align
     dataref: laminar/B738/annunciator/irs_align_left
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 1
     name: left irs on dc
     type: none
     icon: ondc
     dataref: laminar/B738/annunciator/irs_on_dc_left
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 5
     name: left irs fault
     type: none
     icon: fault
     dataref: laminar/B738/annunciator/irs_align_fail_left
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 6
     name: left irs dc fail
     type: none
     icon: dcfail
     dataref: laminar/B738/annunciator/irs_dc_fail_left
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 3
     name: right dc align
     type: none
     icon: align
     dataref: laminar/B738/annunciator/irs_align_right
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 4
     name: right irs on dc
     type: none
     icon: ondc
     dataref: laminar/B738/annunciator/irs_on_dc_right
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 8
     name: right irs fault
     type: none
     icon: fault
     dataref: laminar/B738/annunciator/irs_align_fail_right
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 9
     name: right irs dc fail
     type: none
     icon: dcfail
     dataref: laminar/B738/annunciator/irs_dc_fail_right
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     # irs mode
   - index: 11
     name: lirsmode

--- a/B737-800X/sd15/ctr.yaml
+++ b/B737-800X/sd15/ctr.yaml
@@ -56,13 +56,13 @@ actions:
     type: single
     icon: autobrakedisarm
     dataref: laminar/B738/annunciator/auto_brake_disarm
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 10
     name: anti skid inop
     type: single
     icon: antiskidinop
     dataref: laminar/B738/annunciator/anti_skid_inop
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 8
     name: main panel dus
     type: dual
@@ -102,18 +102,18 @@ actions:
     type: single
     icon: belowgs
     dataref: laminar/B738/annunciator/below_gs
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: laminar/B738/alert/below_gs_pilot
   - index: 1
     name: takeoff config
     type: single
     icon: takeoffconfig
     dataref: laminar/B738/annunciator/takeoff_config
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 2
     name: cabin altitude
     type: single
     icon: cabinaltitude
     dataref: laminar/B738/annunciator/cabin_alt
-    dataref-offset: 0.8
+    dataref-offset: 0.95
  

--- a/B737-800X/sd15/doors.yaml
+++ b/B737-800X/sd15/doors.yaml
@@ -9,40 +9,40 @@ actions:
     type: single
     icon: fwdentry
     dataref: laminar/B738/annunciator/fwd_entry
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: laminar/B738/door/fwd_L_toggle
   - index: 1
     name: fwd r doors
     type: single
     icon: fwdservice
     dataref: laminar/B738/annunciator/fwd_service
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: laminar/B738/door/fwd_R_toggle
   - index: 5
     name: aft l doors
     type: single
     icon: aftentry
     dataref: laminar/B738/annunciator/aft_entry
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: laminar/B738/door/aft_L_toggle
   - index: 6
     name: aft r doors
     type: single
     icon: aftservice
     dataref: laminar/B738/annunciator/aft_service
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: laminar/B738/door/aft_R_toggle
   - index: 2
     name: fwd cargo
     type: single
     icon: fwdcargo
     dataref: laminar/B738/annunciator/fwd_cargo
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: laminar/B738/door/fwd_cargo_toggle
   - index: 7
     name: aft cargo
     type: single
     icon: aftcargo
     dataref: laminar/B738/annunciator/aft_cargo
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: laminar/B738/door/aft_cargo_toggle

--- a/B737-800X/sd15/elec.yaml
+++ b/B737-800X/sd15/elec.yaml
@@ -83,19 +83,19 @@ actions:
     type: none
     icon: batdischarge
     dataref: laminar/B738/annunciator/bat_discharge
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 2
     name: tr unit
     type: none
     icon: trunit
     dataref: laminar/B738/annunciator/tr_unit
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 3
     name: elec
     type: none
     icon: elec
     dataref: laminar/B738/annunciator/elec
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 13
     name: maint
     type: none

--- a/B737-800X/sd15/exttest.yaml
+++ b/B737-800X/sd15/exttest.yaml
@@ -32,18 +32,18 @@ actions:
     icon: extcircuit
     label: APU
     dataref: laminar/B738/annunciator/extinguisher_circuit_annun_apu
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 12
     name: left ext circuit
     type: none
     icon: extcircuit
     label: LEFT
     dataref: laminar/B738/annunciator/extinguisher_circuit_annun_left
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 13
     name: right ext circuit
     type: none
     icon: extcircuit
     label: RIGHT
     dataref: laminar/B738/annunciator/extinguisher_circuit_annun_right
-    dataref-offset: 0.8
+    dataref-offset: 0.95

--- a/B737-800X/sd15/fire.yaml
+++ b/B737-800X/sd15/fire.yaml
@@ -16,7 +16,7 @@ actions:
     type: none
     icon: eng1overheat
     dataref: laminar/B738/annunciator/engine1_ovht
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 8
     type: single
     name: fire ovht test
@@ -29,31 +29,31 @@ actions:
     type: none
     icon: wheelwell
     dataref: laminar/B738/annunciator/wheel_well_fire
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 4
     name: fire fault inop
     type: none
     icon: fault
     dataref: laminar/B738/annunciator/fire_fault_inop
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 6
     name: apu det inop
     type: none
     icon: apudetinop
     dataref: laminar/B738/annunciator/fire_fault_inop # dataref not found
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 7
     name: apu det inop
     type: none
     icon: apubottledischarge
     dataref: laminar/B738/annunciator/apu_bottle_discharge
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 2
     name: eng 2 overheat
     type: none
     icon: eng2overheat
     dataref: laminar/B738/annunciator/engine2_ovht
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 9
     name: exttest
     type: dir
@@ -65,27 +65,27 @@ actions:
     icon: extcircuit
     label: APU
     dataref: laminar/B738/annunciator/extinguisher_circuit_annun_apu
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 11
     name: left ext circuit
     type: none
     icon: extcircuit
     label: LEFT
     dataref: laminar/B738/annunciator/extinguisher_circuit_annun_left
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 12
     name: right ext circuit
     type: none
     icon: extcircuit
     label: RIGHT
     dataref: laminar/B738/annunciator/extinguisher_circuit_annun_right
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 0
     name: fire warning
     type: single
     icon: firewarn
     dataref: laminar/B738/annunciator/fire_bell_annun
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: FlyWithLua/streamdeck_handler/capt_fire_warn_start
     command-release: FlyWithLua/streamdeck_handler/capt_fire_warn_end
   - index: 3
@@ -93,6 +93,6 @@ actions:
     type: single
     icon: ovhtdet
     dataref: laminar/B738/annunciator/six_pack_fire
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: FlyWithLua/streamdeck_handler/capt_six_pack_start
     command-release: FlyWithLua/streamdeck_handler/capt_six_pack_end

--- a/B737-800X/sd15/fltctlnav.yaml
+++ b/B737-800X/sd15/fltctlnav.yaml
@@ -9,7 +9,7 @@ actions:
     type: none
     icon: feeldiffpress
     dataref: laminar/B738/annunciator/feel_diff_press
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 6
     name: speed trim fail
     type: none
@@ -25,7 +25,7 @@ actions:
     type: none
     icon: autoslatfail
     dataref: laminar/B738/annunciator/auto_slat_fail
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 10
     name: spoiler a cover
     type: single

--- a/B737-800X/sd15/fltctlnav2.yaml
+++ b/B737-800X/sd15/fltctlnav2.yaml
@@ -93,4 +93,4 @@ actions:
     type: none
     icon: yawdamper
     dataref: laminar/B738/annunciator/yaw_damp
-    dataref-offset: 0.8
+    dataref-offset: 0.95

--- a/B737-800X/sd15/fuel.yaml
+++ b/B737-800X/sd15/fuel.yaml
@@ -14,7 +14,7 @@ actions:
     name: low press left aft
     type: none
     dataref: laminar/B738/annunciator/low_fuel_press_l1
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     icon: lowpressure
   - index: 0
     name: fuel pump left aft
@@ -29,7 +29,7 @@ actions:
     name: low press left fwd
     type: none
     dataref: laminar/B738/annunciator/low_fuel_press_l2
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     icon: lowpressure
   - index: 1
     name: fuel pump left fwd
@@ -45,7 +45,7 @@ actions:
     name: low press right fwd
     type: none
     dataref: laminar/B738/annunciator/low_fuel_press_r2
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     icon: lowpressure
   - index: 3
     name: fuel pump right fwd
@@ -60,7 +60,7 @@ actions:
     name: low press right aft
     type: none
     dataref: laminar/B738/annunciator/low_fuel_press_r1
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     icon: lowpressure
   - index: 4
     name: fuel pump right aft
@@ -76,7 +76,7 @@ actions:
     name: low press ctr left
     type: none
     dataref: laminar/B738/annunciator/low_fuel_press_c1
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     icon: lowpressure
   - index: 10
     name: fuel pump ctr left
@@ -91,7 +91,7 @@ actions:
     name: low press ctr right
     type: none
     dataref: laminar/B738/annunciator/low_fuel_press_c2
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     icon: lowpressure
   - index: 12
     name: fuel pump ctr right

--- a/B737-800X/sd15/fuel2.yaml
+++ b/B737-800X/sd15/fuel2.yaml
@@ -28,13 +28,13 @@ actions:
     type: none
     icon: filterbypass
     dataref: laminar/B738/annunciator/bypass_filter_1
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 9
     name: filter bypass 5
     type: none
     icon: filterbypass
     dataref: laminar/B738/annunciator/bypass_filter_2
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   # other valves
   - index: 0
     name: eng valve closed 1

--- a/B737-800X/sd15/gen.yaml
+++ b/B737-800X/sd15/gen.yaml
@@ -53,20 +53,20 @@ actions:
       - genoffbus.0.0
       - genoffbus.2.0
     dataref: laminar/B738/annunciator/gen_off_bus2
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 3
     name: gen 2 source off
     type: none
     icon: sourceoff
     dataref: laminar/B738/annunciator/source_off2
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 4
     name: gen 2 transfer bus off
     type: none
     label: GEN 2
     icon: transferbusoff
     dataref: laminar/B738/annunciator/trans_bus_off2
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     # ann 2
   - index: 5
     name: gen 1 off bus
@@ -75,20 +75,20 @@ actions:
       - genoffbus.0.0
       - genoffbus.2.0
     dataref: laminar/B738/annunciator/gen_off_bus1
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 0
     name: gen 1 source off
     type: none
     icon: sourceoff
     dataref: laminar/B738/annunciator/source_off1
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 1
     name: gen 1 transfer bus off
     type: none
     label: GEN 1
     icon: transferbusoff
     dataref: laminar/B738/annunciator/trans_bus_off1
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     # other ann
   - index: 6
     name: apu gen off bus
@@ -98,7 +98,7 @@ actions:
       - apugenoffbus.0.0
       - apugenoffbus.2.0
     dataref: laminar/B738/annunciator/apu_gen_off_bus
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 9
     name: gpu bus
     type: single
@@ -116,7 +116,7 @@ actions:
 #      - gndpoweravailable.0.0
 #      - gndpoweravailable.2.0
 #    dataref: laminar/B738/annunciator/ground_power_avail
-#    dataref-offset: 0.8
+#    dataref-offset: 0.95
     # transfer bus
   - index: 2
     name: transfer bus

--- a/B737-800X/sd15/hydai.yaml
+++ b/B737-800X/sd15/hydai.yaml
@@ -50,35 +50,35 @@ actions:
     type: none
     icon: lowpressure
     dataref: laminar/B738/annunciator/hyd_el_press_a
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 5
     name: low pressure a eng
     type: none
     icon: lowpressure
     dataref: laminar/B738/annunciator/hyd_press_a
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 7
     name: low pressure b elec
     type: none
     icon: lowpressure
     dataref: laminar/B738/annunciator/hyd_el_press_b
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 8
     name: low pressure b eng
     type: none
     icon: lowpressure
     dataref: laminar/B738/annunciator/hyd_press_b
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 11
     name: elec a overheat
     type: none
     icon: overheat
     dataref: laminar/B738/annunciator/el_hyd_ovht_1
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 12
     name: elec b overheat
     type: none
     icon: overheat
     dataref: laminar/B738/annunciator/el_hyd_ovht_2
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   

--- a/B737-800X/sd15/hydai2.yaml
+++ b/B737-800X/sd15/hydai2.yaml
@@ -77,10 +77,10 @@ actions:
     type: none
     icon: cowlantiice
     dataref: laminar/B738/annunciator/cowl_ice_0
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 3
     name: ann orange anti ice 2
     type: none
     icon: cowlantiice
     dataref: laminar/B738/annunciator/cowl_ice_1
-    dataref-offset: 0.8
+    dataref-offset: 0.95

--- a/B737-800X/sd15/left.yaml
+++ b/B737-800X/sd15/left.yaml
@@ -5,7 +5,7 @@ actions:
     type: single
     icon: fltcont
     dataref: laminar/B738/annunciator/six_pack_flt_cont
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: FlyWithLua/streamdeck_handler/capt_six_pack_start
     command-release: FlyWithLua/streamdeck_handler/capt_six_pack_end
   - index: 1
@@ -13,7 +13,7 @@ actions:
     type: single
     icon: elec
     dataref: laminar/B738/annunciator/six_pack_elec
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: FlyWithLua/streamdeck_handler/capt_six_pack_start
     command-release: FlyWithLua/streamdeck_handler/capt_six_pack_end
   - index: 5
@@ -21,7 +21,7 @@ actions:
     type: single
     icon: irs
     dataref: laminar/B738/annunciator/six_pack_irs
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: FlyWithLua/streamdeck_handler/capt_six_pack_start
     command-release: FlyWithLua/streamdeck_handler/capt_six_pack_end
   - index: 6
@@ -29,7 +29,7 @@ actions:
     type: single
     icon: apu
     dataref: laminar/B738/annunciator/six_pack_apu
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: FlyWithLua/streamdeck_handler/capt_six_pack_start
     command-release: FlyWithLua/streamdeck_handler/capt_six_pack_end
   - index: 10
@@ -37,7 +37,7 @@ actions:
     type: single
     icon: fuel
     dataref: laminar/B738/annunciator/six_pack_fuel
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: FlyWithLua/streamdeck_handler/capt_six_pack_start
     command-release: FlyWithLua/streamdeck_handler/capt_six_pack_end
   - index: 11
@@ -45,7 +45,7 @@ actions:
     type: single
     icon: ovhtdet
     dataref: laminar/B738/annunciator/six_pack_fire
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: FlyWithLua/streamdeck_handler/capt_six_pack_start
     command-release: FlyWithLua/streamdeck_handler/capt_six_pack_end
   # capt six-pack end
@@ -55,7 +55,7 @@ actions:
     type: single
     icon: antiice
     dataref: laminar/B738/annunciator/six_pack_ice
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: FlyWithLua/streamdeck_handler/capt_six_pack_start
     command-release: FlyWithLua/streamdeck_handler/capt_six_pack_end
   - index: 4
@@ -63,7 +63,7 @@ actions:
     type: single
     icon: eng
     dataref: laminar/B738/annunciator/six_pack_eng
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: FlyWithLua/streamdeck_handler/capt_six_pack_start
     command-release: FlyWithLua/streamdeck_handler/capt_six_pack_end
   - index: 8
@@ -71,7 +71,7 @@ actions:
     type: single
     icon: hyd
     dataref: laminar/B738/annunciator/six_pack_hyd
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: FlyWithLua/streamdeck_handler/capt_six_pack_start
     command-release: FlyWithLua/streamdeck_handler/capt_six_pack_end
   - index: 9
@@ -79,7 +79,7 @@ actions:
     type: single
     icon: overhead
     dataref: laminar/B738/annunciator/six_pack_overhead
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: FlyWithLua/streamdeck_handler/capt_six_pack_start
     command-release: FlyWithLua/streamdeck_handler/capt_six_pack_end
   - index: 13
@@ -87,7 +87,7 @@ actions:
     type: single
     icon: doors
     dataref: laminar/B738/annunciator/six_pack_doors
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: FlyWithLua/streamdeck_handler/capt_six_pack_start
     command-release: FlyWithLua/streamdeck_handler/capt_six_pack_end
   - index: 14
@@ -95,7 +95,7 @@ actions:
     type: single
     icon: aircond
     dataref: laminar/B738/annunciator/six_pack_air_cond
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: FlyWithLua/streamdeck_handler/capt_six_pack_start
     command-release: FlyWithLua/streamdeck_handler/capt_six_pack_end
     # f/o six pack end
@@ -109,6 +109,6 @@ actions:
     type: single
     icon: mastercaution
     dataref: laminar/B738/annunciator/master_caution_light
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: FlyWithLua/streamdeck_handler/capt_master_caution_start
     command-release: FlyWithLua/streamdeck_handler/capt_master_caution_end

--- a/B737-800X/sd15/lowerovhd1.yaml
+++ b/B737-800X/sd15/lowerovhd1.yaml
@@ -102,14 +102,14 @@ actions:
     icon: lowoilpressure
     label: APU
     dataref: laminar/B738/annunciator/apu_low_oil
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 4
     name: apu fault
     type: none
     icon: fault
     label: APU
     dataref: laminar/B738/annunciator/apu_fault
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 8
     name: apu overspeed
     type: none

--- a/B737-800X/sd15/lowerovhd2.yaml
+++ b/B737-800X/sd15/lowerovhd2.yaml
@@ -9,7 +9,7 @@ actions:
     type: single
     icon: notarmed
     dataref: laminar/B738/annunciator/emer_exit
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 0
     name: arm emer exit lights
     type: single

--- a/B737-800X/sd15/pitots.yaml
+++ b/B737-800X/sd15/pitots.yaml
@@ -23,49 +23,49 @@ actions:
     type: none
     icon: captpitot
     dataref: laminar/B738/annunciator/capt_pitot_off
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 5
     name: l elev pitot
     type: none
     icon: lelevpitot
     dataref: laminar/B738/annunciator/capt_aoa_off
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 10
     name: l alpha pitot
     type: none
     icon: lalphapitot
     dataref: laminar/B738/annunciator/capt_aoa_off
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 1
     name: temp probe
     type: none
     icon: tempprobe
     dataref: laminar/B738/annunciator/capt_aoa_off
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 4
     name: fo pitot
     type: none
     icon: fopitot
     dataref: laminar/B738/annunciator/fo_pitot_off
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 9
     name: r elev pitot
     type: none
     icon: relevpitot
     dataref: laminar/B738/annunciator/fo_aoa_off
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 14
     name: r alpha pitot
     type: none
     icon: ralphapitot
     dataref: laminar/B738/annunciator/fo_aoa_off
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 3
     name: aux probe
     type: none
     icon: auxprobe
     dataref: laminar/B738/annunciator/fo_aoa_off
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     # pitots
   - index: 6
     name: a probe

--- a/B737-800X/sd15/press.yaml
+++ b/B737-800X/sd15/press.yaml
@@ -131,5 +131,5 @@ actions:
     type: none
     icon: dualbleed
     dataref: laminar/B738/annunciator/dual_bleed
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   

--- a/B737-800X/sd15/press2.yaml
+++ b/B737-800X/sd15/press2.yaml
@@ -89,25 +89,25 @@ actions:
     type: none
     icon: autofail
     dataref: laminar/B738/annunciator/autofail
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 1
     name: off sched desc
     type: none
     icon: offscheddescent
     dataref: laminar/B738/annunciator/off_sched_descent
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 2
     name: altnpress
     type: none
     icon: altn
     dataref: laminar/B738/annunciator/altn_press
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 3
     name: manualpress
     type: none
     icon: manual
     dataref: laminar/B738/annunciator/manual_press
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 4
     name: alt horn cutout
     type: single

--- a/B737-800X/sd15/winheat.yaml
+++ b/B737-800X/sd15/winheat.yaml
@@ -60,48 +60,48 @@ actions:
     type: none
     icon: greenon
     dataref: laminar/B738/annunciator/window_heat_l_side
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 6
     name: on left fwd win heat
     type: none
     icon: greenon
     dataref: laminar/B738/annunciator/window_heat_l_fwd
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 7
     name: on right fwd win heat
     type: none
     icon: greenon
     dataref: laminar/B738/annunciator/window_heat_r_fwd
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 8
     name: on right side win heat
     type: none
     icon: greenon
     dataref: laminar/B738/annunciator/window_heat_r_side
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     # ovht ann
   - index: 0
     name: ovht left side win heat
     type: none
     icon: overheat
     dataref: laminar/B738/annunciator/window_heat_ovht_ls
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 1
     name: ovht left fwd win heat
     type: none
     icon: overheat
     dataref: laminar/B738/annunciator/window_heat_ovht_lf
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 2
     name: ovht right fwd win heat
     type: none
     icon: overheat
     dataref: laminar/B738/annunciator/window_heat_ovht_rf
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 3
     name: ovht right side win heat
     type: none
     icon: overheat
     dataref: laminar/B738/annunciator/window_heat_ovht_rs
-    dataref-offset: 0.8
+    dataref-offset: 0.95
  

--- a/B737-800X/sd32/actions.yaml
+++ b/B737-800X/sd32/actions.yaml
@@ -4,7 +4,7 @@ actions:
     type: single
     icon: firewarn
     dataref: laminar/B738/annunciator/fire_bell_annun
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: FlyWithLua/streamdeck_handler/capt_fire_warn_start
     command-release: FlyWithLua/streamdeck_handler/capt_fire_warn_end
   - index: 1
@@ -12,7 +12,7 @@ actions:
     type: single
     icon: mastercaution
     dataref: laminar/B738/annunciator/master_caution_light
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: FlyWithLua/streamdeck_handler/capt_master_caution_start
     command-release: FlyWithLua/streamdeck_handler/capt_master_caution_end
   - index: 2
@@ -20,7 +20,7 @@ actions:
     type: single
     icon: apprst
     dataref: laminar/B738/annunciator/ap_disconnect1
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: FlyWithLua/streamdeck_handler/ap_prst_start
     command-release: FlyWithLua/streamdeck_handler/ap_prst_end
   - index: 3
@@ -28,7 +28,7 @@ actions:
     type: single
     icon: atprst
     dataref: laminar/B738/annunciator/at_disconnect1
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: FlyWithLua/streamdeck_handler/at_prst_start
     command-release: FlyWithLua/streamdeck_handler/at_prst_end
   - index: 4
@@ -36,7 +36,7 @@ actions:
     type: single
     icon: fmcprst
     dataref: laminar/B738/annunciator/at_fms_disconnect1
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: FlyWithLua/streamdeck_handler/fmc_prst_start
     command-release: FlyWithLua/streamdeck_handler/fmc_prst_end
   - index: 5
@@ -44,19 +44,19 @@ actions:
     type: none
     icon: speedbrakearmed
     dataref: laminar/B738/annunciator/speedbrake_armed
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 6
     name: speedbrake do not arm
     type: none
     icon: speedbrakedonotarm
     dataref: laminar/B738/annunciator/speedbrake_extend
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 7
     name: stab out of trim
     type: none
     icon: staboutoftrim
     dataref: laminar/B738/annunciator/stab_out_of_trim
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 27
     name: flaps
     type: dir
@@ -78,13 +78,13 @@ actions:
     type: none
     icon: leflapstransit
     dataref: laminar/B738/annunciator/slats_transit
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 29
     name: le flaps ext
     type: none
     icon: leflapsext
     dataref: laminar/B738/annunciator/slats_extend
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 24
     name: left
     type: dir

--- a/B737-800X/sd32/aftovhd.yaml
+++ b/B737-800X/sd32/aftovhd.yaml
@@ -10,49 +10,49 @@ actions:
     type: none
     icon: align
     dataref: laminar/B738/annunciator/irs_align_left
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 1
     name: left irs on dc
     type: none
     icon: ondc
     dataref: laminar/B738/annunciator/irs_on_dc_left
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 8
     name: left irs fault
     type: none
     icon: fault
     dataref: laminar/B738/annunciator/irs_align_fail_left
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 9
     name: left irs dc fail
     type: none
     icon: dcfail
     dataref: laminar/B738/annunciator/irs_dc_fail_left
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 3
     name: right dc align
     type: none
     icon: align
     dataref: laminar/B738/annunciator/irs_align_right
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 4
     name: right irs on dc
     type: none
     icon: ondc
     dataref: laminar/B738/annunciator/irs_on_dc_right
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 11
     name: right irs fault
     type: none
     icon: fault
     dataref: laminar/B738/annunciator/irs_align_fail_right
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 12
     name: right irs dc fail
     type: none
     icon: dcfail
     dataref: laminar/B738/annunciator/irs_dc_fail_right
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     # irs mode
   - index: 17
     name: lirsmode
@@ -79,7 +79,7 @@ actions:
     type: none
     icon: offann
     dataref: laminar/B738/annunciator/fdr_off
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 22
     name: flt recorder label
     icon: none

--- a/B737-800X/sd32/apuswitch.yaml
+++ b/B737-800X/sd32/apuswitch.yaml
@@ -41,13 +41,13 @@ actions:
     type: none
     icon: lowoilpressure
     dataref: laminar/B738/annunciator/apu_low_oil
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 2
     name: apu fault
     type: none
     icon: fault
     dataref: laminar/B738/annunciator/apu_fault
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 3
     name: apu overspeed
     type: none

--- a/B737-800X/sd32/ctr.yaml
+++ b/B737-800X/sd32/ctr.yaml
@@ -51,13 +51,13 @@ actions:
     type: none
     icon: autobrakedisarm
     dataref: laminar/B738/annunciator/auto_brake_disarm
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 23
     name: anti skid inop
     type: none
     icon: antiskidinop
     dataref: laminar/B738/annunciator/anti_skid_inop
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 8
     name: main panel dus
     type: dual
@@ -97,20 +97,20 @@ actions:
     type: single
     icon: belowgs
     dataref: laminar/B738/annunciator/below_gs
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: laminar/B738/alert/below_gs_pilot
   - index: 1
     name: takeoff config
     type: none
     icon: takeoffconfig
     dataref: laminar/B738/annunciator/takeoff_config
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 2
     name: cabin altitude
     type: none
     icon: cabinaltitude
     dataref: laminar/B738/annunciator/cabin_alt
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 21
     name: eng pfd
     type: single

--- a/B737-800X/sd32/doors.yaml
+++ b/B737-800X/sd32/doors.yaml
@@ -9,40 +9,40 @@ actions:
     type: single
     icon: fwdentry
     dataref: laminar/B738/annunciator/fwd_entry
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: laminar/B738/door/fwd_L_toggle
   - index: 2
     name: fwd r doors
     type: single
     icon: fwdservice
     dataref: laminar/B738/annunciator/fwd_service
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: laminar/B738/door/fwd_R_toggle
   - index: 8
     name: aft l doors
     type: single
     icon: aftentry
     dataref: laminar/B738/annunciator/aft_entry
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: laminar/B738/door/aft_L_toggle
   - index: 10
     name: aft r doors
     type: single
     icon: aftservice
     dataref: laminar/B738/annunciator/aft_service
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: laminar/B738/door/aft_R_toggle
   - index: 11
     name: fwd cargo
     type: single
     icon: fwdcargo
     dataref: laminar/B738/annunciator/fwd_cargo
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: laminar/B738/door/fwd_cargo_toggle
   - index: 19
     name: aft cargo
     type: single
     icon: aftcargo
     dataref: laminar/B738/annunciator/aft_cargo
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: laminar/B738/door/aft_cargo_toggle

--- a/B737-800X/sd32/elec.yaml
+++ b/B737-800X/sd32/elec.yaml
@@ -64,19 +64,19 @@ actions:
     type: none
     icon: batdischarge
     dataref: laminar/B738/annunciator/bat_discharge
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 2
     name: tr unit
     type: none
     icon: trunit
     dataref: laminar/B738/annunciator/tr_unit
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 3
     name: elec
     type: none
     icon: elec
     dataref: laminar/B738/annunciator/elec
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 4
     name: maint
     type: none

--- a/B737-800X/sd32/exttest.yaml
+++ b/B737-800X/sd32/exttest.yaml
@@ -28,16 +28,16 @@ actions:
     type: none
     icon: extcircuit
     dataref: laminar/B738/annunciator/extinguisher_circuit_annun_apu
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 13
     name: left ext circuit
     type: none
     icon: extcircuit
     dataref: laminar/B738/annunciator/extinguisher_circuit_annun_left
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 15
     name: right ext circuit
     type: none
     icon: extcircuit
     dataref: laminar/B738/annunciator/extinguisher_circuit_annun_right
-    dataref-offset: 0.8
+    dataref-offset: 0.95

--- a/B737-800X/sd32/fire.yaml
+++ b/B737-800X/sd32/fire.yaml
@@ -16,7 +16,7 @@ actions:
     type: none
     icon: eng1overheat
     dataref: laminar/B738/annunciator/engine1_ovht
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 26
     type: single
     name: fire ovht test
@@ -29,31 +29,31 @@ actions:
     type: none
     icon: wheelwell
     dataref: laminar/B738/annunciator/wheel_well_fire
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 11
     name: fire fault inop
     type: none
     icon: fault
     dataref: laminar/B738/annunciator/fire_fault_inop
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 19
     name: apu det inop
     type: none
     icon: apudetinop
     dataref: laminar/B738/annunciator/fire_fault_inop # dataref not found
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 27
     name: apu det inop
     type: none
     icon: apubottledischarge
     dataref: laminar/B738/annunciator/apu_bottle_discharge
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 5
     name: eng 2 overheat
     type: none
     icon: eng2overheat
     dataref: laminar/B738/annunciator/engine2_ovht
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 22
     name: exttest
     type: dir
@@ -63,25 +63,25 @@ actions:
     type: none
     icon: extcircuit
     dataref: laminar/B738/annunciator/extinguisher_circuit_annun_apu
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 13
     name: left ext circuit
     type: none
     icon: extcircuit
     dataref: laminar/B738/annunciator/extinguisher_circuit_annun_left
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 15
     name: right ext circuit
     type: none
     icon: extcircuit
     dataref: laminar/B738/annunciator/extinguisher_circuit_annun_right
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 0
     name: fire warning
     type: single
     icon: firewarn
     dataref: laminar/B738/annunciator/fire_bell_annun
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: FlyWithLua/streamdeck_handler/capt_fire_warn_start
     command-release: FlyWithLua/streamdeck_handler/capt_fire_warn_end
   - index: 8
@@ -89,6 +89,6 @@ actions:
     type: single
     icon: ovhtdet
     dataref: laminar/B738/annunciator/six_pack_fire
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: FlyWithLua/streamdeck_handler/capt_six_pack_start
     command-release: FlyWithLua/streamdeck_handler/capt_six_pack_end

--- a/B737-800X/sd32/fltctlnav.yaml
+++ b/B737-800X/sd32/fltctlnav.yaml
@@ -84,7 +84,7 @@ actions:
     type: none
     icon: feeldiffpress
     dataref: laminar/B738/annunciator/feel_diff_press
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 15
     name: speed trim fail
     type: none
@@ -100,7 +100,7 @@ actions:
     type: none
     icon: autoslatfail
     dataref: laminar/B738/annunciator/auto_slat_fail
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 11
     name: spoiler a cover
     type: single
@@ -194,4 +194,4 @@ actions:
     type: none
     icon: yawdamper
     dataref: laminar/B738/annunciator/yaw_damp
-    dataref-offset: 0.8
+    dataref-offset: 0.95

--- a/B737-800X/sd32/fuel.yaml
+++ b/B737-800X/sd32/fuel.yaml
@@ -9,7 +9,7 @@ actions:
     name: low press left aft
     type: none
     dataref: laminar/B738/annunciator/low_fuel_press_l1
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     icon: lowpressure
   - index: 25
     name: fuel pump left aft
@@ -24,7 +24,7 @@ actions:
     name: low press left fwd
     type: none
     dataref: laminar/B738/annunciator/low_fuel_press_l2
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     icon: lowpressure
   - index: 26
     name: fuel pump left fwd
@@ -40,7 +40,7 @@ actions:
     name: low press right fwd
     type: none
     dataref: laminar/B738/annunciator/low_fuel_press_r2
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     icon: lowpressure
   - index: 30
     name: fuel pump right fwd
@@ -55,7 +55,7 @@ actions:
     name: low press right aft
     type: none
     dataref: laminar/B738/annunciator/low_fuel_press_r1
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     icon: lowpressure
   - index: 31
     name: fuel pump right aft
@@ -71,7 +71,7 @@ actions:
     name: low press ctr left
     type: none
     dataref: laminar/B738/annunciator/low_fuel_press_c1
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     icon: lowpressure
   - index: 19
     name: fuel pump ctr left
@@ -86,7 +86,7 @@ actions:
     name: low press ctr right
     type: none
     dataref: laminar/B738/annunciator/low_fuel_press_c2
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     icon: lowpressure
   - index: 21
     name: fuel pump ctr right
@@ -121,13 +121,13 @@ actions:
     type: none
     icon: filterbypass
     dataref: laminar/B738/annunciator/bypass_filter_1
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 5
     name: filter bypass 5
     type: none
     icon: filterbypass
     dataref: laminar/B738/annunciator/bypass_filter_2
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   # other valves
   - index: 1
     name: eng valve closed 1

--- a/B737-800X/sd32/gen.yaml
+++ b/B737-800X/sd32/gen.yaml
@@ -53,19 +53,19 @@ actions:
       - genoffbus.0.0
       - genoffbus.2.0
     dataref: laminar/B738/annunciator/gen_off_bus2
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 15
     name: gen 2 source off
     type: none
     icon: sourceoff
     dataref: laminar/B738/annunciator/source_off2
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 7
     name: gen 2 transfer bus off
     type: none
     icon: transferbusoff
     dataref: laminar/B738/annunciator/trans_bus_off2
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     # ann 2
   - index: 19
     name: gen 1 off bus
@@ -74,19 +74,19 @@ actions:
       - genoffbus.0.0
       - genoffbus.2.0
     dataref: laminar/B738/annunciator/gen_off_bus1
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 11
     name: gen 1 source off
     type: none
     icon: sourceoff
     dataref: laminar/B738/annunciator/source_off1
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 3
     name: gen 1 transfer bus off
     type: none
     icon: transferbusoff
     dataref: laminar/B738/annunciator/trans_bus_off1
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     # other ann
   - index: 21
     name: apu gen off bus
@@ -96,7 +96,7 @@ actions:
       - apugenoffbus.0.0
       - apugenoffbus.2.0
     dataref: laminar/B738/annunciator/apu_gen_off_bus
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 13
     name: gpu bus
     type: single
@@ -114,7 +114,7 @@ actions:
       - gndpoweravailable.0.0
       - gndpoweravailable.2.0
     dataref: laminar/B738/annunciator/ground_power_avail
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     # transfer bus
   - index: 17
     name: transfer bus

--- a/B737-800X/sd32/hydai.yaml
+++ b/B737-800X/sd32/hydai.yaml
@@ -45,37 +45,37 @@ actions:
     type: none
     icon: lowpressure
     dataref: laminar/B738/annunciator/hyd_el_press_a
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 17
     name: low pressure a eng
     type: none
     icon: lowpressure
     dataref: laminar/B738/annunciator/hyd_press_a
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 19
     name: low pressure b elec
     type: none
     icon: lowpressure
     dataref: laminar/B738/annunciator/hyd_el_press_b
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 20
     name: low pressure b eng
     type: none
     icon: lowpressure
     dataref: laminar/B738/annunciator/hyd_press_b
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 10
     name: elec a overheat
     type: none
     icon: overheat
     dataref: laminar/B738/annunciator/el_hyd_ovht_1
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 11
     name: elec b overheat
     type: none
     icon: overheat
     dataref: laminar/B738/annunciator/el_hyd_ovht_2
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     # anti ice
   - index: 29
     name: wing anti ice
@@ -149,10 +149,10 @@ actions:
     type: none
     icon: cowlantiice
     dataref: laminar/B738/annunciator/cowl_ice_0
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 14
     name: ann orange anti ice 2
     type: none
     icon: cowlantiice
     dataref: laminar/B738/annunciator/cowl_ice_1
-    dataref-offset: 0.8
+    dataref-offset: 0.95

--- a/B737-800X/sd32/left.yaml
+++ b/B737-800X/sd32/left.yaml
@@ -5,7 +5,7 @@ actions:
     type: single
     icon: fltcont
     dataref: laminar/B738/annunciator/six_pack_flt_cont
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: FlyWithLua/streamdeck_handler/capt_six_pack_start
     command-release: FlyWithLua/streamdeck_handler/capt_six_pack_end
   - index: 3
@@ -13,7 +13,7 @@ actions:
     type: single
     icon: elec
     dataref: laminar/B738/annunciator/six_pack_elec
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: FlyWithLua/streamdeck_handler/capt_six_pack_start
     command-release: FlyWithLua/streamdeck_handler/capt_six_pack_end
   - index: 10
@@ -21,7 +21,7 @@ actions:
     type: single
     icon: irs
     dataref: laminar/B738/annunciator/six_pack_irs
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: FlyWithLua/streamdeck_handler/capt_six_pack_start
     command-release: FlyWithLua/streamdeck_handler/capt_six_pack_end
   - index: 11
@@ -29,7 +29,7 @@ actions:
     type: single
     icon: apu
     dataref: laminar/B738/annunciator/six_pack_apu
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: FlyWithLua/streamdeck_handler/capt_six_pack_start
     command-release: FlyWithLua/streamdeck_handler/capt_six_pack_end
   - index: 18
@@ -37,7 +37,7 @@ actions:
     type: single
     icon: fuel
     dataref: laminar/B738/annunciator/six_pack_fuel
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: FlyWithLua/streamdeck_handler/capt_six_pack_start
     command-release: FlyWithLua/streamdeck_handler/capt_six_pack_end
   - index: 19
@@ -45,7 +45,7 @@ actions:
     type: single
     icon: ovhtdet
     dataref: laminar/B738/annunciator/six_pack_fire
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: FlyWithLua/streamdeck_handler/capt_six_pack_start
     command-release: FlyWithLua/streamdeck_handler/capt_six_pack_end
     # capt six pack end
@@ -54,7 +54,7 @@ actions:
     type: single
     icon: firewarn
     dataref: laminar/B738/annunciator/fire_bell_annun
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: FlyWithLua/streamdeck_handler/capt_fire_warn_start
     command-release: FlyWithLua/streamdeck_handler/capt_fire_warn_end
   - index: 1
@@ -62,7 +62,7 @@ actions:
     type: single
     icon: mastercaution
     dataref: laminar/B738/annunciator/master_caution_light
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: FlyWithLua/streamdeck_handler/capt_master_caution_start
     command-release: FlyWithLua/streamdeck_handler/capt_master_caution_end
   # f/o six pack start
@@ -71,7 +71,7 @@ actions:
     type: single
     icon: antiice
     dataref: laminar/B738/annunciator/six_pack_ice
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: FlyWithLua/streamdeck_handler/capt_six_pack_start
     command-release: FlyWithLua/streamdeck_handler/capt_six_pack_end
   - index: 6
@@ -79,7 +79,7 @@ actions:
     type: single
     icon: eng
     dataref: laminar/B738/annunciator/six_pack_eng
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: FlyWithLua/streamdeck_handler/capt_six_pack_start
     command-release: FlyWithLua/streamdeck_handler/capt_six_pack_end
   - index: 13
@@ -87,7 +87,7 @@ actions:
     type: single
     icon: hyd
     dataref: laminar/B738/annunciator/six_pack_hyd
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: FlyWithLua/streamdeck_handler/capt_six_pack_start
     command-release: FlyWithLua/streamdeck_handler/capt_six_pack_end
   - index: 14
@@ -95,7 +95,7 @@ actions:
     type: single
     icon: overhead
     dataref: laminar/B738/annunciator/six_pack_overhead
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: FlyWithLua/streamdeck_handler/capt_six_pack_start
     command-release: FlyWithLua/streamdeck_handler/capt_six_pack_end
   - index: 21
@@ -103,7 +103,7 @@ actions:
     type: single
     icon: doors
     dataref: laminar/B738/annunciator/six_pack_doors
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: FlyWithLua/streamdeck_handler/capt_six_pack_start
     command-release: FlyWithLua/streamdeck_handler/capt_six_pack_end
   - index: 22
@@ -111,7 +111,7 @@ actions:
     type: single
     icon: aircond
     dataref: laminar/B738/annunciator/six_pack_air_cond
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     command: FlyWithLua/streamdeck_handler/capt_six_pack_start
     command-release: FlyWithLua/streamdeck_handler/capt_six_pack_end
     # f/o six pack end

--- a/B737-800X/sd32/lirsmode.yaml
+++ b/B737-800X/sd32/lirsmode.yaml
@@ -4,25 +4,25 @@ actions:
     type: none
     icon: align
     dataref: laminar/B738/annunciator/irs_align_left
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 1
     name: left irs on dc
     type: none
     icon: ondc
     dataref: laminar/B738/annunciator/irs_on_dc_left
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 8
     name: left irs fault
     type: none
     icon: fault
     dataref: laminar/B738/annunciator/irs_align_fail_left
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 9
     name: left irs dc fail
     type: none
     icon: dcfail
     dataref: laminar/B738/annunciator/irs_dc_fail_left
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 17
     name: return
     type: dir

--- a/B737-800X/sd32/lowerovhd.yaml
+++ b/B737-800X/sd32/lowerovhd.yaml
@@ -259,7 +259,7 @@ actions:
     type: none
     icon: notarmed
     dataref: laminar/B738/annunciator/emer_exit
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 6
     name: arm emer exit lights
     type: single
@@ -308,13 +308,13 @@ actions:
     type: none
     icon: lowoilpressure
     dataref: laminar/B738/annunciator/apu_low_oil
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 2
     name: apu fault
     type: none
     icon: fault
     dataref: laminar/B738/annunciator/apu_fault
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 3
     name: apu overspeed
     type: none

--- a/B737-800X/sd32/press.yaml
+++ b/B737-800X/sd32/press.yaml
@@ -206,31 +206,31 @@ actions:
     type: none
     icon: dualbleed
     dataref: laminar/B738/annunciator/dual_bleed
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 0
     name: auto fail
     type: none
     icon: autofail
     dataref: laminar/B738/annunciator/autofail
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 1
     name: off sched desc
     type: none
     icon: offscheddescent
     dataref: laminar/B738/annunciator/off_sched_descent
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 2
     name: altnpress
     type: none
     icon: altn
     dataref: laminar/B738/annunciator/altn_press
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 3
     name: manualpress
     type: none
     icon: manual
     dataref: laminar/B738/annunciator/manual_press
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 19
     name: alt horn cutout
     type: single

--- a/B737-800X/sd32/rirsmode.yaml
+++ b/B737-800X/sd32/rirsmode.yaml
@@ -4,25 +4,25 @@ actions:
     type: none
     icon: align
     dataref: laminar/B738/annunciator/irs_align_right
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 4
     name: right irs on dc
     type: none
     icon: ondc
     dataref: laminar/B738/annunciator/irs_on_dc_right
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 11
     name: right irs fault
     type: none
     icon: fault
     dataref: laminar/B738/annunciator/irs_align_fail_right
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 12
     name: right irs dc fail
     type: none
     icon: dcfail
     dataref: laminar/B738/annunciator/irs_dc_fail_right
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 19
     name: return
     type: dir

--- a/B737-800X/sd32/winheat.yaml
+++ b/B737-800X/sd32/winheat.yaml
@@ -73,99 +73,99 @@ actions:
     type: none
     icon: greenon
     dataref: laminar/B738/annunciator/window_heat_l_side
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 9
     name: on left fwd win heat
     type: none
     icon: greenon
     dataref: laminar/B738/annunciator/window_heat_l_fwd
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 11
     name: on right fwd win heat
     type: none
     icon: greenon
     dataref: laminar/B738/annunciator/window_heat_r_fwd
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 12
     name: on right side win heat
     type: none
     icon: greenon
     dataref: laminar/B738/annunciator/window_heat_r_side
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     # ovht ann
   - index: 0
     name: ovht left side win heat
     type: none
     icon: overheat
     dataref: laminar/B738/annunciator/window_heat_ovht_ls
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 1
     name: ovht left fwd win heat
     type: none
     icon: overheat
     dataref: laminar/B738/annunciator/window_heat_ovht_lf
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 3
     name: ovht right fwd win heat
     type: none
     icon: overheat
     dataref: laminar/B738/annunciator/window_heat_ovht_rf
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 4
     name: ovht right side win heat
     type: none
     icon: overheat
     dataref: laminar/B738/annunciator/window_heat_ovht_rs
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     # ann pitots
   - index: 5
     name: capt pitot
     type: none
     icon: captpitot
     dataref: laminar/B738/annunciator/capt_pitot_off
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 13
     name: l elev pitot
     type: none
     icon: lelevpitot
     dataref: laminar/B738/annunciator/capt_aoa_off
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 21
     name: l alpha pitot
     type: none
     icon: lalphapitot
     dataref: laminar/B738/annunciator/capt_aoa_off
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 29
     name: temp probe
     type: none
     icon: tempprobe
     dataref: laminar/B738/annunciator/capt_aoa_off
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 7
     name: fo pitot
     type: none
     icon: fopitot
     dataref: laminar/B738/annunciator/fo_pitot_off
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 15
     name: r elev pitot
     type: none
     icon: relevpitot
     dataref: laminar/B738/annunciator/fo_aoa_off
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 23
     name: r alpha pitot
     type: none
     icon: ralphapitot
     dataref: laminar/B738/annunciator/fo_aoa_off
-    dataref-offset: 0.8
+    dataref-offset: 0.95
   - index: 31
     name: aux probe
     type: none
     icon: auxprobe
     dataref: laminar/B738/annunciator/fo_aoa_off
-    dataref-offset: 0.8
+    dataref-offset: 0.95
     # pitots
   - index: 14
     name: a probe


### PR DESCRIPTION
Further work on #8 
Light of the day affects the float value of Zibo annunciators, of observed minimum `0.5`.