### PR TITLE
Added generic configurations for G430/530 and G1000 avionics using Stream Deck+

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,13 @@ works the best together with other simulator peripherals (e.g. radio, A/P panel 
 
 **Supported planes:**
 
-| Aircraft       | 15 keys | 32 keys |
-|----------------|---------|---------|
-| Cessna 172SP   | ❌       | ✅✅      |
-| Zibo 737-800   | ✅       | ✅✅      |
-| JARDesign A320 | ✅       | ❌       |
+| Aircraft       | 15 keys | 32 keys | Steamdeck+ |
+|----------------|---------|---------|------------|
+| Cessna 172SP   | ❌       | ✅✅      | ❌  |
+| Zibo 737-800   | ✅       | ✅✅      | ❌  |
+| JARDesign A320 | ✅       | ❌       | ❌   |
+| Generic G430/530 avionics | ❌ | ❌ | ✅ |
+| Generic G1000 avionics | ❌ | ❌ | ✅ |
 
 ✅✅ - Stable configuration, expecting minor fixes only
 

--- a/config.yaml
+++ b/config.yaml
@@ -24,4 +24,4 @@ cache-path: ./ # current folder
 stream-decks:
   - serial: secret.yaml # ! VERIFY THE SERIAL KEY IN THIS FILE IF YOU HAVE MORE THAN ONE STREAM DECK !
     brightness: 75 # Brightness of the Stream Deck (0-100)
-    active-preset: g430_530
+    active-preset: g1000

--- a/config.yaml
+++ b/config.yaml
@@ -24,4 +24,4 @@ cache-path: ./ # current folder
 stream-decks:
   - serial: secret.yaml # ! VERIFY THE SERIAL KEY IN THIS FILE IF YOU HAVE MORE THAN ONE STREAM DECK !
     brightness: 75 # Brightness of the Stream Deck (0-100)
-    active-preset: B737-800X
+    active-preset: g430_530

--- a/g1000/config.yaml
+++ b/g1000/config.yaml
@@ -1,0 +1,18 @@
+# font used for labels (displays use different one)
+default-font: IBMPlexMono-Bold.ttf
+default-font-size: 13
+
+# set False if you want lower case labels
+only-uppercase: True # True / False
+
+# use caching of the graphics
+# this creates a file in the plane's preset directory
+# and is loaded every time after start
+# of the xplane-streamdeck, saving precious CPU power and time.
+# Leaving this enabled is recommended, unless you are actively debugging or reconfiguring the configuration/graphics.
+# Note that if you change some settings regarding the plane sets, you should delete the .pkl file to be reloaded
+caching-enabled: True  # True / False
+
+# this flag is used for overriding loaded configurations that the software detects automatically
+# force-config: sd15
+force-config: False # [config-directory-name] / False

--- a/g1000/sd8/actions.yaml
+++ b/g1000/sd8/actions.yaml
@@ -1,0 +1,145 @@
+actions:
+  - index: 0
+    type: single
+    icon: none-gray
+    name: CDI
+    command: sim/GPS/g1000n1_softkey6
+    special-labels:
+      - label: CDI
+        text-center:
+          x: center
+          y: center
+        font-path: IBMPlexMono-Bold.ttf
+        font-size: 48
+        color: white
+        direction: ltr
+        align: center
+  - index: 1
+    type: single
+    icon: none-gray
+    name: FPL
+    command: sim/GPS/g1000n3_fpl
+    special-labels:
+      - label: FPL
+        text-center:
+          x: center
+          y: center
+        font-path: IBMPlexMono-Bold.ttf
+        font-size: 48
+        color: white
+        direction: ltr
+        align: center
+  - index: 2
+    type: single
+    icon: none-gray
+    name: DCT
+    command: sim/GPS/g1000n3_direct
+    special-labels:
+      - label: DCT
+        text-center:
+          x: center
+          y: center
+        font-path: IBMPlexMono-Bold.ttf
+        font-size: 48
+        color: white
+        direction: ltr
+        align: center
+  - index: 3
+    type: single
+    icon: none-gray
+    name: CLR
+    command: sim/GPS/g1000n3_clr
+    special-labels:
+      - label: CLR
+        text-center:
+          x: center
+          y: center
+        font-path: IBMPlexMono-Bold.ttf
+        font-size: 48
+        color: white
+        direction: ltr
+        align: center
+  - index: 4
+    type: single
+    icon: none-gray
+    name: OBS
+    command: sim/GPS/g1000n1_softkey5
+    special-labels:
+      - label: OBS
+        text-center:
+          x: center
+          y: center
+        font-path: IBMPlexMono-Bold.ttf
+        font-size: 48
+        color: white
+        direction: ltr
+        align: center
+  - index: 5
+    type: single
+    icon: none-gray
+    name: PROC
+    command: sim/GPS/g1000n3_proc
+    special-labels:
+      - label: PROC
+        text-center:
+          x: center
+          y: center
+        font-path: IBMPlexMono-Bold.ttf
+        font-size: 46
+        color: white
+        direction: ltr
+        align: center
+  - index: 6
+    type: single
+    icon: none-gray
+    name: MENU
+    command: sim/GPS/g1000n3_menu
+    special-labels:
+      - label: MENU
+        text-center:
+          x: center
+          y: center
+        font-path: IBMPlexMono-Bold.ttf
+        font-size: 46
+        color: white
+        direction: ltr
+        align: center
+  - index: 7
+    type: single
+    icon: none-gray
+    name: ENT
+    command: sim/GPS/g1000n3_ent
+    special-labels:
+      - label: ENT
+        text-center:
+          x: center
+          y: center
+        font-path: IBMPlexMono-Bold.ttf
+        font-size: 48
+        color: white
+        direction: ltr
+        align: center
+  - index: 8
+    type: dial
+    name: BARO
+    command-right: sim/GPS/g1000n1_baro_up
+    command-left: sim/GPS/g1000n1_baro_down
+    command: sim/instruments/barometer_std
+  - index: 9
+    type: dial
+    name: RANGE
+    command-right: sim/GPS/g1000n3_range_up
+    command-left: sim/GPS/g1000n3_range_down
+    command: sim/GPS/g1000n3_popup
+  - index: 10
+    type: dial
+    name: OUTER
+    command-right: sim/GPS/g1000n3_fms_outer_up
+    command-left: sim/GPS/g1000n3_fms_outer_down
+    command: sim/GPS/g1000n3_cursor
+  - index: 11
+    type: dial
+    name: INNER
+    command-right: sim/GPS/g1000n3_fms_inner_up
+    command-left: sim/GPS/g1000n3_fms_inner_down
+    command: sim/GPS/g1000n3_cursor

--- a/g430_530/config.yaml
+++ b/g430_530/config.yaml
@@ -1,0 +1,18 @@
+# font used for labels (displays use different one)
+default-font: IBMPlexMono-Bold.ttf
+default-font-size: 13
+
+# set False if you want lower case labels
+only-uppercase: True # True / False
+
+# use caching of the graphics
+# this creates a file in the plane's preset directory
+# and is loaded every time after start
+# of the xplane-streamdeck, saving precious CPU power and time.
+# Leaving this enabled is recommended, unless you are actively debugging or reconfiguring the configuration/graphics.
+# Note that if you change some settings regarding the plane sets, you should delete the .pkl file to be reloaded
+caching-enabled: True  # True / False
+
+# this flag is used for overriding loaded configurations that the software detects automatically
+# force-config: sd15
+force-config: False # [config-directory-name] / False

--- a/g430_530/sd8/actions.yaml
+++ b/g430_530/sd8/actions.yaml
@@ -1,0 +1,145 @@
+actions:
+  - index: 0
+    type: single
+    icon: none-gray
+    name: CDI
+    command: sim/GPS/g430n1_cdi
+    special-labels:
+      - label: CDI
+        text-center:
+          x: center
+          y: center
+        font-path: IBMPlexMono-Bold.ttf
+        font-size: 48
+        color: white
+        direction: ltr
+        align: center
+  - index: 1
+    type: single
+    icon: none-gray
+    name: FPL
+    command: sim/GPS/g430n1_fpl
+    special-labels:
+      - label: FPL
+        text-center:
+          x: center
+          y: center
+        font-path: IBMPlexMono-Bold.ttf
+        font-size: 48
+        color: white
+        direction: ltr
+        align: center
+  - index: 2
+    type: single
+    icon: none-gray
+    name: DCT
+    command: sim/GPS/g430n1_direct
+    special-labels:
+      - label: DCT
+        text-center:
+          x: center
+          y: center
+        font-path: IBMPlexMono-Bold.ttf
+        font-size: 48
+        color: white
+        direction: ltr
+        align: center
+  - index: 3
+    type: single
+    icon: none-gray
+    name: CLR
+    command: sim/GPS/g430n1_clr
+    special-labels:
+      - label: CLR
+        text-center:
+          x: center
+          y: center
+        font-path: IBMPlexMono-Bold.ttf
+        font-size: 48
+        color: white
+        direction: ltr
+        align: center
+  - index: 4
+    type: single
+    icon: none-gray
+    name: OBS
+    command: sim/GPS/g430n1_obs
+    special-labels:
+      - label: OBS
+        text-center:
+          x: center
+          y: center
+        font-path: IBMPlexMono-Bold.ttf
+        font-size: 48
+        color: white
+        direction: ltr
+        align: center
+  - index: 5
+    type: single
+    icon: none-gray
+    name: PROC
+    command: sim/GPS/g430n1_proc
+    special-labels:
+      - label: PROC
+        text-center:
+          x: center
+          y: center
+        font-path: IBMPlexMono-Bold.ttf
+        font-size: 46
+        color: white
+        direction: ltr
+        align: center
+  - index: 6
+    type: single
+    icon: none-gray
+    name: MENU
+    command: sim/GPS/g430n1_menu
+    special-labels:
+      - label: MENU
+        text-center:
+          x: center
+          y: center
+        font-path: IBMPlexMono-Bold.ttf
+        font-size: 46
+        color: white
+        direction: ltr
+        align: center
+  - index: 7
+    type: single
+    icon: none-gray
+    name: ENT
+    command: sim/GPS/g430n1_ent
+    special-labels:
+      - label: ENT
+        text-center:
+          x: center
+          y: center
+        font-path: IBMPlexMono-Bold.ttf
+        font-size: 48
+        color: white
+        direction: ltr
+        align: center
+  - index: 8
+    type: dial
+    name: BARO
+    command-right: sim/instruments/barometer_up
+    command-left: sim/instruments/barometer_down
+    command: sim/instruments/barometer_std
+  - index: 9
+    type: dial
+    name: CHAPTER
+    command-right: sim/GPS/g430n1_zoom_in
+    command-left: sim/GPS/g430n1_zoom_out
+    command: sim/GPS/g430n1_popup
+  - index: 10
+    type: dial
+    name: CHAPTER
+    command-right: sim/GPS/g430n1_chapter_up
+    command-left: sim/GPS/g430n1_chapter_dn
+    command: sim/GPS/g430n1_cursor
+  - index: 11
+    type: dial
+    name: PAGE
+    command-right: sim/GPS/g430n1_page_up
+    command-left: sim/GPS/g430n1_page_dn
+    command: sim/GPS/g430n1_cursor

--- a/xpsd/configuration.py
+++ b/xpsd/configuration.py
@@ -17,11 +17,13 @@ class RunningConfig(object):
         self.only_uppercase = False
         self.active_config_path = join(assetio.ROOT_PATH, self.active_config)
         self.local_cfg = assetio.load_local_cfg(self.active_config_path)
+        assert self.local_cfg is not None
 
         # only the first configuration works for now
         serial = assetio.load_serial(current_preset["serial"])
         self.active_deck = None
         self.key_count = 0
+        self.dial_count = 0
         self.connect_streamdeck(serial, current_preset.get("brightness"))
 
         # load config paths
@@ -74,6 +76,7 @@ class RunningConfig(object):
                 deck.set_brightness(brightness)
                 self.active_deck = deck
                 self.key_count = deck.key_count()
+                self.dial_count = deck.dial_count()
                 logger.warning("Serial number not set in the secret file. "
                                "If you run only one Stream Deck, this shouldn't matter")
                 logger.info("Deck {} with {} keys setting as default for current session"
@@ -82,6 +85,7 @@ class RunningConfig(object):
             if s == serial:
                 self.active_deck = deck
                 self.key_count = deck.key_count()
+                self.dial_count = deck.dial_count()
                 logger.info("Deck {} with {} keys setting as default for the current session"
                             .format(index, self.key_count))
                 return
@@ -89,6 +93,7 @@ class RunningConfig(object):
         sys.exit(1)
 
     def read_local_cfg(self):
+        assert self.local_cfg is not None
         try:
             self.default_font, self.default_font_size = \
                 assetio.load_default_font(self.local_cfg["default-font"], self.local_cfg["default-font-size"])
@@ -102,6 +107,7 @@ class RunningConfig(object):
             sys.exit(1)
 
     def load_caching_options(self):
+        assert self.local_cfg is not None
         if self.local_cfg["caching-enabled"]:
             self.cache_path = join(self.active_config_path,
                                    assetio.get_keyset_cache_name(self.key_count, self.local_cfg["force-config"]))

--- a/xpsd/const.py
+++ b/xpsd/const.py
@@ -21,7 +21,7 @@ ACTION_CFG = "actions.yaml"
 ACTION_CFG_ALIAS = "actions"
 
 VITAL_FIELDS = ["index", "name"]
-CMD_TYPES = ["none", "dir", "single", "dual"]
+CMD_TYPES = ["none", "dir", "single", "dual", "dial"]
 
 GAUGE_FIELDS = ["name", "background", "needle", "min", "max", "step", "needle-center", "range-degrees"]
 DISPLAY_FIELDS = ["name", "text-center", "font-path", "font-size", "zero-pad",

--- a/xpsd/sanity.py
+++ b/xpsd/sanity.py
@@ -51,7 +51,7 @@ def label_check(index, name, label):
 # checks if the commands are set corresponding to its cmd_type
 # this just generates warnings, doesn't return anything
 def cmd2_check(index, name, cmd_type, cmd=None, cmd_mul=None, cmd_release=None, cmd_release_mul=None,
-               cmd_on=None, cmd_off=None, cmd_on_mul=None, cmd_off_mul=None):
+               cmd_on=None, cmd_off=None, cmd_on_mul=None, cmd_off_mul=None, cmd_dial_left=None, cmd_dial_right=None):
     if cmd_type == "none":
         if cmd or cmd_mul or cmd_release or cmd_release_mul or cmd_on or cmd_off or cmd_on_mul or cmd_off_mul:
             logging.warning("#{} {} has set type of 'none', but commands are set too. The commands won't work"
@@ -73,6 +73,10 @@ def cmd2_check(index, name, cmd_type, cmd=None, cmd_mul=None, cmd_release=None, 
             logging.warning("#{} {} has set type of 'dual' and release commands are set too. "
                             "The commands will be executed, but it's weird. "
                             "If it's intentional, you can ignore this message."
+                            .format(index, name))
+    elif cmd_type == "dial":
+        if not cmd_dial_left or not cmd_dial_right:
+            logging.warning("#{} {} has set type of 'dial', but commands left and right are not set"
                             .format(index, name))
     return
 


### PR DESCRIPTION
I've adapted the code to support the steam deck+, which has 8 buttons and 4 dials. I used this to make configurations for the G430/530 and G1000 avionics so the stream deck can be used to enter/edit flight plans, navigate the map, etc... Buttons like MENU, DIRECT TO, FPL, PROC, and etc are modelled. And the four dials are used for: 

* barometer
* map zoom
* FMS outer knob
* FMS inner knob

I have not included radio com/nav bindings because I have a separate radio deck for that.